### PR TITLE
Allow using activation keys for RH subscriptions

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,6 +71,8 @@ Update the following variables specific to the nodes.
  * `public_key` :(Optional) The contents of corresponding key to use for the connection. Ignored if `public_key_file` is provided.
  * `rhel_subscription_username` : (Optional) The username required for RHEL subcription on bastion host. Leave empty if repos are already set in the bastion_image and subscription is not needed.
  * `rhel_subscription_password` : (Optional) The password required for RHEL subcription on bastion host.
+ * `rhel_subscription_org` : (Optional) The organization to use for RHEL subscription if username/password is unsuitable
+ * `rhel_subscription_activationkey` : (Optional) The activation key to use in conjunction with an organization
 
 ### Setup OpenShift Variables
 

--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -145,6 +145,9 @@ then
     sudo subscription-manager register --username=${var.rhel_subscription_username} --password=${var.rhel_subscription_password} --force
     sudo subscription-manager refresh
     sudo subscription-manager attach --auto
+elif [ '${var.rhel_subscription_org}' != '' ]
+then
+   sudo subscription-manager register --activationkey=${var.rhel_subscription_activationkey} --org=${var.rhel_subscription_org} --force
 fi
 EOF
         ]

--- a/modules/1_prepare/variables.tf
+++ b/modules/1_prepare/variables.tf
@@ -49,6 +49,8 @@ variable "images_path" { default = "/home/libvirt/openshift/images" }
 
 variable "rhel_subscription_username" {}
 variable "rhel_subscription_password" {}
+variable "rhel_subscription_org" {}
+variable "rhel_subscription_activationkey" {}
 
 variable "storage_type" {}
 variable "volume_size" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -100,6 +100,8 @@ module "prepare" {
     images_path                     = var.images_path
     rhel_subscription_username      = var.rhel_subscription_username
     rhel_subscription_password      = var.rhel_subscription_password
+    rhel_subscription_org           = var.rhel_subscription_org
+    rhel_subscription_activationkey = var.rhel_subscription_activationkey
     storage_type                    = var.storage_type
     volume_size                     = var.volume_size
 }

--- a/var.tfvars
+++ b/var.tfvars
@@ -18,8 +18,10 @@ public_key_file             = "~/.ssh/id_rsa.pub"
 private_key_file            = "~/.ssh/id_rsa"
 private_key                 = ""
 public_key                  = ""
-rhel_subscription_username  = ""
-rhel_subscription_password  = ""
+rhel_subscription_username      = ""
+rhel_subscription_password      = ""
+rhel_subscription_org           = ""
+rhel_subscription_activationkey = ""
 
 ### OpenShift variables
 # openshift_install_tarball   = ""

--- a/variables.tf
+++ b/variables.tf
@@ -124,12 +124,21 @@ variable "public_key" {
     default     = ""
 }
 
-# Won't subscribe if rhel_subscription_username is empty (default).
+# Will attempt subscription if this or rhel_subscription_org are set
 variable "rhel_subscription_username" {
     default = ""
 }
 
 variable "rhel_subscription_password" {
+    default = ""
+}
+
+# Will attempt subscription if this or rhel_subscription_username are set
+variable "rhel_subscription_org" {
+    default = ""
+}
+
+variable "rhel_subscription_activationkey" {
     default = ""
 }
 


### PR DESCRIPTION
This method allows using subscription-manager with organization-level
credentials. It's mainly useful for automation, as it divorces
subscription credentials from personal Red Hat accounts.

See https://access.redhat.com/solutions/3341191 for more information.

Signed-off-by: Zack Cerza <zack@redhat.com>