### PR TITLE
Add chrony_config and chrony_config_servers vars

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -90,6 +90,8 @@ Update the following variables specific to OCP.
  * `install_playbook_tag` : (Optional) [ocp4-playbooks](https://github.com/ocp-power-automation/ocp4-playbooks) ansible playbooks version to checkout.
  * `pull_secret_file` : (Optional) Location of the pull-secret file to be used. Default path is 'data/pull-secret.txt'.
  * `dns_forwarders` : (Optional) External DNS servers to forward DNS queries that cannot resolve locally. Eg: `"8.8.8.8; 9.9.9.9"`.
+ * `chrony_config`: (Optional) Whether to enable NTP via chronyd. Default: true
+ * `chrony_config_servers`: (Optional) NTP servers to use with chrony, e.g. `[{server: "ntp.example.com", options: "iburst"}]`. The default value is `[]`, which uses chronyd's default servers.
 
 ### Setup Storage Variables
 

--- a/modules/3_helpernode/helpernode.tf
+++ b/modules/3_helpernode/helpernode.tf
@@ -32,7 +32,10 @@ locals {
         pool            = var.allocation_pools[0]
         forwarder1      = local.forwarders[0]
         forwarder2      = length(local.forwarders) > 1 ? join(";", slice(local.forwarders, 1, length(local.forwarders))) : ""
-	
+
+        chrony_config         = var.chrony_config
+        chrony_config_servers = var.chrony_config_servers
+
         bootstrap_info  = {
             ip = var.bootstrap_ip,
             mac = var.bootstrap_mac,

--- a/modules/3_helpernode/templates/helpernode_vars.yaml
+++ b/modules/3_helpernode/templates/helpernode_vars.yaml
@@ -32,6 +32,15 @@ workers:
     ipaddr: "${w.ip}"
     macaddr: "${w.mac}"
 %{ endfor ~}
+chronyconfig:
+  enabled: ${chrony_config}
+%{ if chrony_config_servers != [] ~}
+  content:
+%{ for item in chrony_config_servers ~}
+    - server: ${item.server}
+      options: ${lookup(item, "options", "iburst")}
+%{ endfor ~}
+%{ endif ~}
 
 ppc64le: true
 ssh_gen_key: false

--- a/modules/3_helpernode/variables.tf
+++ b/modules/3_helpernode/variables.tf
@@ -26,6 +26,8 @@ variable "cluster_id" {
 }
 
 variable "dns_forwarders" {}
+variable "chrony_config" {}
+variable "chrony_config_servers" {}
 variable "gateway_ip" {}
 variable "cidr" {}
 variable "allocation_pools" {}

--- a/modules/5_install/install.tf
+++ b/modules/5_install/install.tf
@@ -34,6 +34,8 @@ locals {
         storage_type            = var.storage_type
         log_level               = var.log_level
         release_image_override  = var.release_image_override
+        chrony_config           = var.chrony_config
+        chrony_config_servers   = var.chrony_config_servers
     }
 
     upgrade_vars = {

--- a/modules/5_install/templates/install_vars.yaml
+++ b/modules/5_install/templates/install_vars.yaml
@@ -9,3 +9,12 @@ workdir: ~/openstack-upi
 storage_type: ${storage_type}
 log_level: ${log_level}
 release_image_override: '${release_image_override}'
+chronyconfig:
+  enabled: ${chrony_config}
+%{ if chrony_config_servers != [] ~}
+  content:
+%{ for item in chrony_config_servers ~}
+    - server: ${item.server}
+      options: ${lookup(item, "options", "iburst")}
+%{ endfor ~}
+%{ endif ~}

--- a/modules/5_install/variables.tf
+++ b/modules/5_install/variables.tf
@@ -31,6 +31,9 @@ variable "private_key" {}
 variable "ssh_agent" {}
 variable "jump_host" { default = "" }
 
+variable "chrony_config" {}
+variable "chrony_config_servers" {}
+
 variable "bootstrap_ip" {}
 variable "master_ips" {}
 variable "worker_ips" {}

--- a/ocp.tf
+++ b/ocp.tf
@@ -113,6 +113,8 @@ module "helpernode" {
     cluster_domain                  = var.cluster_domain
     cluster_id                      = local.cluster_id
     dns_forwarders                  = var.dns_forwarders
+    chrony_config                   = var.chrony_config
+    chrony_config_servers           = var.chrony_config_servers
     gateway_ip                      = cidrhost(var.network_cidr,1)
     cidr                            = var.network_cidr
     allocation_pools                = [{"start": cidrhost(var.network_cidr,3), "end": cidrhost(var.network_cidr,-2)}]
@@ -164,6 +166,8 @@ module "install" {
     private_key                     = local.private_key
     ssh_agent                       = var.ssh_agent
     jump_host                       = var.host_address
+    chrony_config                   = var.chrony_config
+    chrony_config_servers           = var.chrony_config_servers
     bootstrap_ip                    = local.bootstrap.ip
     master_ips                      = null_resource.master_info.*.triggers.ip
     worker_ips                      = null_resource.worker_info.*.triggers.ip

--- a/var.tfvars
+++ b/var.tfvars
@@ -35,6 +35,8 @@ cluster_id_prefix           = "test"
 cluster_id                  = ""
 
 dns_forwarders              = "1.1.1.1; 9.9.9.9"
+chrony_config               = true
+chrony_config_servers       = []
 installer_log_level         = "info"
 ansible_extra_options       = "-v"
 

--- a/variables.tf
+++ b/variables.tf
@@ -219,6 +219,16 @@ variable "dns_forwarders" {
     default = "8.8.8.8; 8.8.4.4"
 }
 
+variable chrony_config {
+    description = "If true, set enable time synchronization via chronyd. Default: true"
+    default = true
+}
+
+variable chrony_config_servers {
+    default = []
+    # example: chrony_config_servers = [{server = "clock.example.com", options="iburst"}]
+}
+
 variable "storage_type" {
     #Supported values: nfs (other value won't setup a storageclass)
     default = "none"


### PR DESCRIPTION
This will optionally instruct chronyd to use a non-default server
instead of the default pool. Necessary in cases where corporate
firewalls block NTP traffic.

Signed-off-by: Zack Cerza <zack@redhat.com>