### PR TITLE
Fix dns forwarders in bastion node

### DIFF
--- a/modules/3_helpernode/helpernode.tf
+++ b/modules/3_helpernode/helpernode.tf
@@ -19,17 +19,20 @@
 ################################################################
 
 locals {
+    forwarders = tolist(split(";", var.dns_forwarders))
+
     helpernode_vars = {
         cluster_domain  = var.cluster_domain
         cluster_id      = var.cluster_id
         bastion_ip      = var.bastion_ip
-        forwarders      = var.dns_forwarders
         gateway_ip      = var.gateway_ip
         netmask         = cidrnetmask(var.cidr)
         broadcast       = cidrhost(var.cidr,-1)
         ipid            = cidrhost(var.cidr, 0)
         pool            = var.allocation_pools[0]
-
+        forwarder1      = local.forwarders[0]
+        forwarder2      = length(local.forwarders) > 1 ? join(";", slice(local.forwarders, 1, length(local.forwarders))) : ""
+	
         bootstrap_info  = {
             ip = var.bootstrap_ip,
             mac = var.bootstrap_mac,

--- a/modules/3_helpernode/templates/helpernode_vars.yaml
+++ b/modules/3_helpernode/templates/helpernode_vars.yaml
@@ -6,7 +6,8 @@ helper:
 dns:
   domain: "${cluster_domain}"
   clusterid: "${cluster_id}"
-  forwarder1: "${forwarders}"
+  forwarder1: "${forwarder1}"
+  forwarder2: "${forwarder2}"
 dhcp:
   router: "${gateway_ip}"
   bcast: "${broadcast}"


### PR DESCRIPTION
The dns interface to the ocp4-helpernode project is forwarder1 and
forwarder2.  Presently, only forwarder1 is specified and the
ocp4-helpernode project adds the second forwarder which has a
default value of 8.8.4.4.

The dns interface to the ocp4-upi-kvm project is a string composed
of multiple dns servers, so it needs to be translated into forwarder1
and forwarder2.  This is not presently happening.  This results in
3 dns servers being defined in the bastion node, including the
extra dns server 8.8.4.4 which was not requested.

Redhat OCS utilizes NTP servers that are behind the firewall which are
frequently not resolved correctly due to the use of dns server 8.8.4.4.
The following line appears thousands of times in /var/log/messages.

Oct 16 10:31:27 nx144-ahv dnsmasq[36993]: Maximum number of concurrent DNS queries reached (max: 150)

The OCS configuration requires that all dns requests be forwarded to
the host server which is accomplished by specifying 192.168.88.1 and
127.0.0.1, both of which resolve to the host server.

The too many concurrent dns request error message no longer occur
with this change.

Signed-off-by: Luke Browning <lukebrowning@us.ibm.com>