### PR TITLE
Allow one dns server to be specified by user

### DIFF
--- a/modules/3_helpernode/templates/helpernode_vars.yaml
+++ b/modules/3_helpernode/templates/helpernode_vars.yaml
@@ -7,7 +7,9 @@ dns:
   domain: "${cluster_domain}"
   clusterid: "${cluster_id}"
   forwarder1: "${forwarder1}"
+%{ if forwarder2 != "" ~}
   forwarder2: "${forwarder2}"
+%{ endif ~}
 dhcp:
   router: "${gateway_ip}"
   bcast: "${broadcast}"


### PR DESCRIPTION
The ocp4-helpernode will add a second dns server

Signed-off-by: Luke Browning <lukebrowning@us.ibm.com>