### PR TITLE
Name virtual machine names with unique suffix

### DIFF
--- a/modules/4_nodes/nodes.tf
+++ b/modules/4_nodes/nodes.tf
@@ -128,11 +128,18 @@ resource "libvirt_ignition" "worker" {
     pool        = var.storage_pool_name
 }
 
+resource "random_string" "vm-name-suffix" {
+    length  = 6
+    upper   = false
+    number  = false
+    lower   = true
+    special = false
+}
 
 # domains
 resource "libvirt_domain" "bootstrap" {
     count   = var.bootstrap["count"] == 0 ? 0 : 1
-    name    = "${var.cluster_id}-bootstrap"
+    name    = "${var.cluster_id}-bootstrap-${random_string.vm-name-suffix.result}"
     memory  = var.bootstrap.memory
     vcpu    = var.bootstrap.vcpu
 
@@ -157,7 +164,7 @@ resource "libvirt_domain" "bootstrap" {
 
 resource "libvirt_domain" "master" {
     count   = var.master["count"]
-    name    = "${var.cluster_id}-master-${count.index}"
+    name    = "${var.cluster_id}-master-${count.index}-${random_string.vm-name-suffix.result}"
     memory  = var.master.memory
     vcpu    = var.master.vcpu
 
@@ -182,7 +189,7 @@ resource "libvirt_domain" "master" {
 
 resource "libvirt_domain" "worker" {
     count   = var.worker["count"]
-    name    = "${var.cluster_id}-worker-${count.index}"
+    name    = "${var.cluster_id}-worker-${count.index}-${random_string.vm-name-suffix.result}"
     memory  = var.worker.memory
     vcpu    = var.worker.vcpu
 


### PR DESCRIPTION
This will help to have unique hostnames for master and worker
nodes when OCP is deployed. Unique hostname for master and
worker node is needed to overcome docker.io ratelimit issue.

Signed-off-by: Sridhar Venkat <svenkat@MacBook-Pro-4.attlocal.net>