### PR TITLE
Add gcc to prepare bastion package install list

### DIFF
--- a/modules/1_prepare/prepare.tf
+++ b/modules/1_prepare/prepare.tf
@@ -157,7 +157,7 @@ EOF
         inline = [
             "#sudo dnf update -y --skip-broken",
             "sudo dnf install -y wget jq git net-tools bind-utils vim python3 python3-devel httpd tar",
-            "sudo dnf install -y openssl-devel libffi-devel"
+            "sudo dnf install -y openssl-devel libffi-devel gcc"
         ]
     }
     provisioner "remote-exec" {


### PR DESCRIPTION
Using a RHEL 8.3 bastion image, the ansible package fails to pip install
as the cryptology module cannot be compiled as there is no compiler.

The error manifests as:

module.prepare.null_resource.bastion_init (remote-exec): Connected!
module.prepare.null_resource.bastion_init: Still creating... [2m20s elapsed]
module.prepare.null_resource.bastion_init: Still creating... [2m30s elapsed]
module.prepare.null_resource.bastion_init: Still creating... [2m40s elapsed]
module.prepare.null_resource.bastion_init: Still creating... [2m50s elapsed]
module.prepare.null_resource.bastion_init (remote-exec): Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-2bd3sfun/cryptography/Error: error executing "/tmp/terraform_1470345862.sh": Process exited with status 1

Signed-off-by: Luke Browning <lukebrowning@us.ibm.com>